### PR TITLE
COMPILE_FLAGS in C/CXXFLAGS instead of CPPFLAGS

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -27,13 +27,16 @@ add_custom_target(clean-stamps
 ## Set the default compile and link flags for external projects
 
 # Preprocessor flags
-string(REPLACE ";" " " CPPFLAGS "$ENV{CPPFLAGS} ${COMPILE_OPTIONS}")
+set(CPPFLAGS "$ENV{CPPFLAGS}")
+
+# General compile flags
+string(REPLACE ";" " " COMPILEFLAGS "${COMPILE_OPTIONS}")
 
 # C compiler flags
-set(CFLAGS   "${CPPFLAGS} -w -Wimplicit -Werror")
+set(CFLAGS   "${COMPILEFLAGS} -w -Wimplicit -Werror")
 
 # C++ compiler flags
-set(CXXFLAGS "${CPPFLAGS} -std=gnu++11 -w -Wno-mismatched-tags -Wno-deprecated-register")
+set(CXXFLAGS "${COMPILEFLAGS} -std=gnu++11 -w -Wno-mismatched-tags -Wno-deprecated-register")
 
 # Linker flags
 string(REPLACE ";" " " LDFLAGS "${LINK_OPTIONS}")


### PR DESCRIPTION
Put COMPILE_FLAGS in the corresponding C/CXXFLAGS variable, instead of CPPFLAGS which is for pre-processor flags.

This fixes a bug where when `-march=native` was in COMPILE_FLAGS (for example when BUILD_NATIVE is on), `./configure` would fail to pick up the proper architecture in the 4ti2 compilation as autoconf uses non-standard flags ordering and thus `-march=native` would shadow whatever `-march=` flag was being tested, falsifying the result, and leading to a failing compilation.

See https://savannah.gnu.org/support/?110484 for more.